### PR TITLE
aacraid: avoid calling pci_free_consistent on NULL pointer.

### DIFF
--- a/drivers/scsi/aacraid/commsup.c
+++ b/drivers/scsi/aacraid/commsup.c
@@ -83,9 +83,11 @@ static int fib_map_alloc(struct aac_dev *dev)
 
 void aac_fib_map_free(struct aac_dev *dev)
 {
-	pci_free_consistent(dev->pdev,
-	  dev->max_fib_size * (dev->scsi_host_ptr->can_queue + AAC_NUM_MGT_FIB),
-	  dev->hw_fib_va, dev->hw_fib_pa);
+	if (dev->hw_fib_va) {
+		pci_free_consistent(dev->pdev,
+		  dev->max_fib_size * (dev->scsi_host_ptr->can_queue + AAC_NUM_MGT_FIB),
+		  dev->hw_fib_va, dev->hw_fib_pa);
+	}
 	dev->hw_fib_va = NULL;
 	dev->hw_fib_pa = 0;
 }


### PR DESCRIPTION
When the adapter initialize fails, pci_free_consistent() may get called with a NULL pointer and zero size. Calling pci_free_consistent() with a zero size effectively results in a hang because an attempt is made to invalidate all pages in the 64-bit address space.